### PR TITLE
use the 'epoch' that begins with January 1st, 2015 in IdGenerator.java

### DIFF
--- a/com.kksk.identify/src/main/java/com/kksk/identify/IdGenerator.java
+++ b/com.kksk.identify/src/main/java/com/kksk/identify/IdGenerator.java
@@ -1,8 +1,15 @@
 package com.kksk.identify;
 
+import java.util.Date;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class IdGenerator {
+
+	/**
+	 * epoch.<br>
+	 * our default ‘epoch’ begins on January 1st, 2015.
+	 */
+	private static final long EPOCH = 1420038000000L;
 	private static final long LEN_TIMESTAMP = 41L;
 	private static final long LEN_SHARD_ID = 12L;
 	private static final long LEN_SEQUENCE = 10L;
@@ -19,7 +26,7 @@ public final class IdGenerator {
 			throw new RuntimeException("Invalid value..." + shardId);
 		}
 		long result = 0;
-		result = System.currentTimeMillis();
+		result = System.currentTimeMillis() - EPOCH;
 		if (sequence.compareAndSet(MASK_SEQUENCE, 0)) {
 			result++;
 		}
@@ -30,4 +37,13 @@ public final class IdGenerator {
 		result += (sequence.getAndIncrement() & MASK_SEQUENCE);
 		return result;
 	}
+
+	public static final long getIdByTimestamp(final Date date) {
+		long result = 0;
+		result = date.getTime() - EPOCH;
+		result &= MASK_TIMESTAMP;
+		result <<= LEN_TIMESTAMP;
+		return result;
+	}
+
 }


### PR DESCRIPTION
Because IdGenerator was using the epoch / Unix timestamp, modified to use the January 1st, 2015 as the epoch.
